### PR TITLE
feat: Paperless-ngx webhook integration for real-time receipt processing

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -11,6 +11,7 @@ import processing from './routes/processing'
 import worker from './routes/worker'
 import queue from './routes/queue'
 import stats from './routes/stats'
+import webhooks from './routes/webhooks'
 import ws from './routes/ws'
 import { websocket } from 'hono/bun'
 import { createLogger } from '@sm-rn/core'
@@ -39,6 +40,7 @@ app.route('/api/processing', processing)
 app.route('/api/worker', worker)
 app.route('/api/queue', queue)
 app.route('/api/stats', stats)
+app.route('/api/webhooks', webhooks)
 
 // Export app for RPC type inference (named export to avoid Bun's auto-serve)
 export { app }

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -1,0 +1,103 @@
+import { Hono } from 'hono';
+import { loadConfig, workerState, webhookQueueService, createLogger } from '@sm-rn/core';
+
+const logger = createLogger('api');
+const webhooks = new Hono();
+
+// POST /api/webhooks/paperless — Receive Paperless-ngx workflow webhook
+webhooks.post('/paperless', async (c) => {
+  const config = loadConfig();
+
+  // 1. Check if webhooks are enabled
+  if (!config.webhooks?.enabled) {
+    return c.json({ error: 'Webhooks are disabled' }, 403);
+  }
+
+  // 2. Validate Authorization header (if secret is configured)
+  if (config.webhooks.secret) {
+    const authHeader = c.req.header('Authorization');
+    const expectedToken = `Bearer ${config.webhooks.secret}`;
+    if (!authHeader || authHeader !== expectedToken) {
+      logger.warn('Webhook rejected: invalid or missing Authorization header');
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+  }
+
+  // 3. Parse payload (flexible: JSON or form data)
+  let documentId: number | undefined;
+  let rawPayload: string | undefined;
+
+  try {
+    const contentType = c.req.header('Content-Type') || '';
+    if (contentType.includes('application/json')) {
+      const body = await c.req.json();
+      documentId = parseInt(body.document_id, 10);
+      rawPayload = JSON.stringify(body);
+    } else if (contentType.includes('form')) {
+      const body = await c.req.parseBody();
+      documentId = parseInt(body.document_id as string, 10);
+      rawPayload = JSON.stringify(body);
+    } else {
+      // Try JSON parsing as fallback
+      try {
+        const body = await c.req.json();
+        documentId = parseInt(body.document_id, 10);
+        rawPayload = JSON.stringify(body);
+      } catch {
+        return c.json({ error: 'Unsupported content type. Use application/json or form data.' }, 400);
+      }
+    }
+  } catch (error) {
+    logger.error('Failed to parse webhook payload', error);
+    return c.json({ error: 'Failed to parse request body' }, 400);
+  }
+
+  // 4. Validate document ID
+  if (!documentId || isNaN(documentId)) {
+    return c.json({ error: 'Missing or invalid document_id in payload' }, 400);
+  }
+
+  // 5. Queue for processing and trigger scan
+  try {
+    await webhookQueueService.enqueue(documentId, rawPayload);
+    await workerState.triggerScan();
+
+    logger.info(`Webhook received: document ${documentId} queued for processing`);
+
+    // 6. Return 200 immediately (Paperless has 5s timeout)
+    return c.json({ status: 'queued', documentId });
+  } catch (error) {
+    logger.error('Failed to enqueue webhook', error);
+    return c.json({ error: 'Internal server error' }, 500);
+  }
+});
+
+// GET /api/webhooks/status — Webhook configuration info and queue stats
+webhooks.get('/status', async (c) => {
+  try {
+    const config = loadConfig();
+    const stats = await webhookQueueService.getStats();
+
+    return c.json({
+      enabled: config.webhooks?.enabled ?? false,
+      hasSecret: !!config.webhooks?.secret,
+      queue: stats,
+    });
+  } catch (error) {
+    return c.json({ error: String(error) }, 500);
+  }
+});
+
+// GET /api/webhooks/history — Recent webhook deliveries
+webhooks.get('/history', async (c) => {
+  try {
+    const limit = parseInt(c.req.query('limit') || '50', 10);
+    const entries = await webhookQueueService.getRecent(limit);
+
+    return c.json(entries);
+  } catch (error) {
+    return c.json({ error: String(error) }, 500);
+  }
+});
+
+export default webhooks;

--- a/apps/webapp/src/lib/queries.ts
+++ b/apps/webapp/src/lib/queries.ts
@@ -23,6 +23,7 @@ import {
   getCurrencyTotals as getCurrencyTotalsFn,
   getDocumentThumbnail,
   getDocumentImage,
+  getWebhookStatus as getWebhookStatusFn,
   type HealthStatus,
   type SaveConfigResponse,
   type TestConnectionResponse,
@@ -32,6 +33,7 @@ import {
   type TriggerScanResponse,
   type CurrencyTotalsResponse,
   type DocumentImageResponse,
+  type WebhookStatusResponse,
 } from './server';
 
 // Re-export types for convenience
@@ -46,6 +48,7 @@ export type {
   ProcessingLog,
   CurrencyTotalsResponse,
   DocumentImageResponse,
+  WebhookStatusResponse,
 };
 export type { Config };
 
@@ -77,6 +80,11 @@ export const workerKeys = {
 export const queueKeys = {
   all: ['queue'] as const,
   status: () => [...queueKeys.all, 'status'] as const,
+};
+
+export const webhookKeys = {
+  all: ['webhooks'] as const,
+  status: () => [...webhookKeys.all, 'status'] as const,
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -356,5 +364,20 @@ export function useClearSkipped() {
       queryClient.invalidateQueries({ queryKey: healthKeys.all });
       queryClient.invalidateQueries({ queryKey: queueKeys.all });
     },
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Webhook Queries
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Fetches webhook status (enabled state, secret presence, queue stats).
+ */
+export function useWebhookStatus() {
+  return useQuery({
+    queryKey: webhookKeys.status(),
+    queryFn: () => getWebhookStatusFn(),
+    refetchInterval: 30_000,
   });
 }

--- a/apps/webapp/src/lib/server/index.ts
+++ b/apps/webapp/src/lib/server/index.ts
@@ -43,3 +43,8 @@ export {
     getDocumentImage,
     type DocumentImageResponse,
 } from './documents.functions';
+export {
+    getWebhookStatus,
+    type WebhookStatusResponse,
+    type WebhookQueueStats,
+} from './webhooks.functions';

--- a/apps/webapp/src/lib/server/webhooks.functions.ts
+++ b/apps/webapp/src/lib/server/webhooks.functions.ts
@@ -1,0 +1,47 @@
+import { createServerFn } from '@tanstack/react-start';
+
+// API base URL - in production this would be internal, in dev it's localhost
+const API_BASE_URL = process.env.API_URL || 'http://localhost:3001';
+
+/**
+ * Internal fetch wrapper for calling the API from server functions.
+ */
+async function apiCall<T>(path: string, options: RequestInit = {}): Promise<T> {
+    const url = `${API_BASE_URL}${path}`;
+
+    const response = await fetch(url, {
+        ...options,
+        headers: {
+            'Content-Type': 'application/json',
+            ...options.headers,
+        },
+    });
+
+    if (!response.ok) {
+        const error = await response.json().catch(() => ({ error: response.statusText }));
+        throw new Error(error.error || error.message || `API error: ${response.status}`);
+    }
+
+    return response.json();
+}
+
+export interface WebhookQueueStats {
+    pending: number;
+    processing: number;
+    completed: number;
+    failed: number;
+    total: number;
+}
+
+export interface WebhookStatusResponse {
+    enabled: boolean;
+    hasSecret: boolean;
+    queue: WebhookQueueStats;
+}
+
+/**
+ * Get webhook status - proxies to GET /api/webhooks/status
+ */
+export const getWebhookStatus = createServerFn({ method: 'GET' }).handler(async (): Promise<WebhookStatusResponse> => {
+    return apiCall<WebhookStatusResponse>('/api/webhooks/status');
+});

--- a/apps/webapp/src/routes/settings.tsx
+++ b/apps/webapp/src/routes/settings.tsx
@@ -11,7 +11,10 @@ import {
   ArrowLeft,
   Server,
   Activity,
-  Coins
+  Coins,
+  Webhook,
+  Copy,
+  RefreshCw,
 } from 'lucide-react'
 
 import { Button } from '../components/ui/button'
@@ -33,7 +36,8 @@ import {
   useSaveConfig, 
   useTestPaperless, 
   useTestAi,
-  useAvailableCurrencies
+  useAvailableCurrencies,
+  useWebhookStatus
 } from '../lib/queries'
 import { FetchError, type ZodIssue } from '../lib/api'
 import { type Config, type AIProvider, PartialConfigSchema } from '@sm-rn/shared/schemas'
@@ -61,6 +65,7 @@ function SettingsPage() {
   const testPaperlessMutation = useTestPaperless()
   const testAiMutation = useTestAi()
   const { data: availableCurrencies = [] } = useAvailableCurrencies()
+  const { data: webhookStatus } = useWebhookStatus()
 
   const [errors, setErrors] = useState<Record<string, string>>({})
 
@@ -99,6 +104,10 @@ function SettingsPage() {
     observability: {
       heliconeEnabled: false,
       heliconeApiKey: ''
+    },
+    webhooks: {
+      enabled: false,
+      secret: ''
     }
   })
 
@@ -184,6 +193,35 @@ function SettingsPage() {
     })
   }
 
+  const handleWebhooksChange = (field: keyof NonNullable<Config['webhooks']>, value: any) => {
+    setLocalConfig(prev => ({
+      ...prev,
+      webhooks: { ...prev.webhooks!, [field]: value }
+    }))
+    setErrors(prev => {
+      const next = { ...prev }
+      delete next[`webhooks.${field}`]
+      return next
+    })
+  }
+
+  const generateWebhookSecret = () => {
+    const array = new Uint8Array(32)
+    crypto.getRandomValues(array)
+    const secret = Array.from(array, b => b.toString(16).padStart(2, '0')).join('')
+    handleWebhooksChange('secret', secret)
+    toast.success('Generated new webhook secret')
+  }
+
+  const copyWebhookUrl = () => {
+    const url = `${window.location.origin}/api/webhooks/paperless`
+    navigator.clipboard.writeText(url).then(() => {
+      toast.success('Webhook URL copied to clipboard')
+    }).catch(() => {
+      toast.error('Failed to copy to clipboard')
+    })
+  }
+
   const handleTestPaperless = async () => {
     if (!localConfig.paperless.host || !localConfig.paperless.apiKey) {
       toast.warning('Please fill in Paperless host and API key')
@@ -254,6 +292,9 @@ function SettingsPage() {
     }
     if (payload.observability && isMasked(payload.observability.heliconeApiKey)) {
       delete payload.observability.heliconeApiKey
+    }
+    if (payload.webhooks && isMasked(payload.webhooks.secret)) {
+      delete payload.webhooks.secret
     }
 
     // Clean up empty nested objects
@@ -710,6 +751,118 @@ function SettingsPage() {
                 )}
               </div>
             </div>
+          </CardContent>
+        </Card>
+
+        {/* Webhooks */}
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <Webhook className="h-5 w-5" />
+              <CardTitle>Webhooks</CardTitle>
+            </div>
+            <CardDescription>
+              Receive real-time notifications from Paperless-ngx when documents are added
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <Label htmlFor="webhooks-enabled" className="font-medium">Enable Webhooks</Label>
+                <p className="text-[10px] text-muted-foreground mt-0.5">
+                  Accept incoming webhook notifications from Paperless-ngx for near-instant processing
+                </p>
+              </div>
+              <Switch
+                id="webhooks-enabled"
+                checked={localConfig.webhooks?.enabled ?? false}
+                onCheckedChange={(checked) => handleWebhooksChange('enabled', checked)}
+              />
+            </div>
+
+            {localConfig.webhooks?.enabled && (
+              <div className="grid gap-4 pl-6 border-l-2 border-gray-100 ml-2">
+                {/* Webhook URL (read-only) */}
+                <div className="grid gap-2">
+                  <Label>Webhook URL</Label>
+                  <div className="flex gap-2">
+                    <Input
+                      readOnly
+                      value={typeof window !== 'undefined' ? `${window.location.origin}/api/webhooks/paperless` : '/api/webhooks/paperless'}
+                      className="font-mono text-xs bg-muted"
+                    />
+                    <Button variant="outline" size="sm" onClick={copyWebhookUrl}>
+                      <Copy className="h-4 w-4" />
+                    </Button>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Use this URL in your Paperless-ngx workflow webhook action
+                  </p>
+                </div>
+
+                {/* Secret Token */}
+                <div className="grid gap-2">
+                  <Label htmlFor="webhook-secret">Secret Token (optional)</Label>
+                  <div className="flex gap-2">
+                    <Input
+                      id="webhook-secret"
+                      type="password"
+                      placeholder="Leave empty for no authentication"
+                      value={localConfig.webhooks?.secret || ''}
+                      onChange={(e) => handleWebhooksChange('secret', e.target.value)}
+                      className={errors['webhooks.secret'] ? 'border-destructive' : ''}
+                    />
+                    <Button variant="outline" size="sm" onClick={generateWebhookSecret}>
+                      <RefreshCw className="h-4 w-4" />
+                    </Button>
+                  </div>
+                  <ErrorMessage path="webhooks.secret" />
+                  <p className="text-xs text-muted-foreground">
+                    If set, Paperless must send this token as a Bearer token in the Authorization header
+                  </p>
+                </div>
+
+                {/* Queue Status */}
+                {webhookStatus && (
+                  <div className="rounded-lg border border-border/50 bg-muted/30 p-3">
+                    <h4 className="text-sm font-medium mb-2">Queue Status</h4>
+                    <div className="grid grid-cols-4 gap-2 text-center text-xs">
+                      <div>
+                        <div className="font-semibold text-lg">{webhookStatus.queue.pending}</div>
+                        <div className="text-muted-foreground">Pending</div>
+                      </div>
+                      <div>
+                        <div className="font-semibold text-lg">{webhookStatus.queue.processing}</div>
+                        <div className="text-muted-foreground">Processing</div>
+                      </div>
+                      <div>
+                        <div className="font-semibold text-lg">{webhookStatus.queue.completed}</div>
+                        <div className="text-muted-foreground">Completed</div>
+                      </div>
+                      <div>
+                        <div className="font-semibold text-lg">{webhookStatus.queue.failed}</div>
+                        <div className="text-muted-foreground">Failed</div>
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                {/* Setup instructions */}
+                <div className="rounded-lg border border-border/50 bg-muted/30 p-3">
+                  <h4 className="text-sm font-medium mb-2">Paperless-ngx Setup</h4>
+                  <ol className="text-xs text-muted-foreground space-y-1 list-decimal list-inside">
+                    <li>Go to <strong>Settings &rarr; Workflows</strong> in Paperless-ngx</li>
+                    <li>Create a new workflow triggered on <strong>Document Added</strong></li>
+                    <li>Add a <strong>Webhook</strong> action with the URL above</li>
+                    <li>Set the body to: <code className="bg-background px-1 rounded">{'{"document_id": "{{ document_id }}"}'}</code></li>
+                    {localConfig.webhooks?.secret && (
+                      <li>Add a custom header: <code className="bg-background px-1 rounded">Authorization: Bearer {'<your-secret>'}</code></li>
+                    )}
+                    <li>Save and test with a new document upload</li>
+                  </ol>
+                </div>
+              </div>
+            )}
           </CardContent>
         </Card>
 

--- a/packages/core/drizzle/0001_hard_abomination.sql
+++ b/packages/core/drizzle/0001_hard_abomination.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `webhook_queue` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`documentId` integer NOT NULL,
+	`source` text DEFAULT 'paperless' NOT NULL,
+	`payload` text,
+	`status` text DEFAULT 'pending' NOT NULL,
+	`receivedAt` text NOT NULL,
+	`processedAt` text
+);

--- a/packages/core/drizzle/meta/0001_snapshot.json
+++ b/packages/core/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,424 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "4e4ad6b5-de43-4f08-9095-ed51c0a917c0",
+  "prevId": "6d9ac9a7-c74f-4e9b-b884-67d4e8717b3e",
+  "tables": {
+    "logs": {
+      "name": "logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "processing_logs": {
+      "name": "processing_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "fileName": {
+          "name": "fileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "receiptData": {
+          "name": "receiptData",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "retry_queue": {
+      "name": "retry_queue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nextRetryAt": {
+          "name": "nextRetryAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "retry_queue_documentId_unique": {
+          "name": "retry_queue_documentId_unique",
+          "columns": [
+            "documentId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skipped_documents": {
+      "name": "skipped_documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fileName": {
+          "name": "fileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skippedAt": {
+          "name": "skippedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "skipped_documents_documentId_unique": {
+          "name": "skipped_documents_documentId_unique",
+          "columns": [
+            "documentId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_queue": {
+      "name": "webhook_queue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'paperless'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "receivedAt": {
+          "name": "receivedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "worker_state": {
+      "name": "worker_state",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "isPaused": {
+          "name": "isPaused",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "pausedAt": {
+          "name": "pausedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pauseReason": {
+          "name": "pauseReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scanRequested": {
+          "name": "scanRequested",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "lastScanResult": {
+          "name": "lastScanResult",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastScanCompletedAt": {
+          "name": "lastScanCompletedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isRunning": {
+          "name": "isRunning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/drizzle/meta/_journal.json
+++ b/packages/core/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1769766036769,
       "tag": "0000_thick_tyrannus",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1770977103309,
+      "tag": "0001_hard_abomination",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -70,3 +70,17 @@ export const skippedDocumentsSchema = sqliteTable('skipped_documents', {
 
 export type SkippedDocumentEntry = typeof skippedDocumentsSchema.$inferSelect;
 export type NewSkippedDocumentEntry = typeof skippedDocumentsSchema.$inferInsert;
+
+// Webhook queue for storing document IDs received from Paperless-ngx webhooks
+export const webhookQueue = sqliteTable('webhook_queue', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  documentId: integer('documentId').notNull(),
+  source: text('source').notNull().default('paperless'), // Future: support multiple webhook sources
+  payload: text('payload'), // Raw JSON payload for debugging
+  status: text('status').notNull().default('pending'), // 'pending' | 'processing' | 'completed' | 'failed'
+  receivedAt: text('receivedAt').notNull(), // ISO date string
+  processedAt: text('processedAt'), // ISO date string, null until processed
+});
+
+export type WebhookQueueEntry = typeof webhookQueue.$inferSelect;
+export type NewWebhookQueueEntry = typeof webhookQueue.$inferInsert;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,3 +12,4 @@ export * from './services/reporter';
 export * from './services/logger';
 export * from './services/worker-state';
 export * from './services/skipped-documents';
+export * from './services/webhook-queue';

--- a/packages/core/src/services/bridge.ts
+++ b/packages/core/src/services/bridge.ts
@@ -665,3 +665,55 @@ export async function runAutomation(): Promise<{
   };
 }
 
+/**
+ * Process specific documents by ID (webhook-triggered).
+ * Unlike runAutomation(), this skips discovery and processes only the given IDs.
+ * 
+ * Note: Concurrency control is handled by the caller via workerState.acquireLock()
+ */
+export async function processDocumentsByIds(documentIds: number[]): Promise<{
+  processed: number;
+  failed: number;
+  skipped: number;
+}> {
+  logger.info(`Processing ${documentIds.length} webhook-queued document(s): [${documentIds.join(', ')}]`);
+
+  // Load configuration
+  let config;
+  try {
+    config = loadConfig();
+  } catch (error: any) {
+    logger.error('Failed to load configuration', { error: error.message });
+    return { processed: 0, failed: documentIds.length, skipped: 0 };
+  }
+
+  // Initialize Paperless client
+  const client = new PaperlessClient({
+    host: config.paperless.host,
+    apiKey: config.paperless.apiKey,
+    processedTagName: config.processing.processedTag,
+  });
+
+  // Create AI adapter
+  const adapter = createAIAdapter(config);
+  const retryQueue = new RetryQueue(config.processing.maxRetries);
+
+  let processed = 0;
+  let failed = 0;
+  let skipped = 0;
+
+  for (const documentId of documentIds) {
+    try {
+      await reporter.report('receipt:detected', { documentId, status: 'detected', progress: 0 });
+      await processPaperlessDocument(client, documentId, adapter, retryQueue, config.processing.failedTag);
+      processed++;
+    } catch (error: any) {
+      logger.error(`Failed to process webhook-queued document ${documentId}`, { error: error.message });
+      failed++;
+    }
+  }
+
+  logger.info(`Webhook-queued processing complete: ${processed} processed, ${failed} failed, ${skipped} skipped`);
+  return { processed, failed, skipped };
+}
+

--- a/packages/core/src/services/config.ts
+++ b/packages/core/src/services/config.ts
@@ -44,6 +44,10 @@ function getDefaultConfigTemplate(): Record<string, unknown> {
       heliconeEnabled: false,
       heliconeApiKey: '',
     },
+    webhooks: {
+      enabled: false,
+      secret: '',
+    },
   };
 }
 
@@ -183,6 +187,14 @@ export function loadConfig(): Config {
         process.env.HELICONE_ENABLED === 'true'
       ),
       heliconeApiKey: getConfigValue(fileConfig, ['observability', 'heliconeApiKey'], process.env.HELICONE_API_KEY),
+    },
+    webhooks: {
+      enabled: getConfigValueBoolean(
+        fileConfig,
+        ['webhooks', 'enabled'],
+        process.env.WEBHOOK_ENABLED === 'true'
+      ),
+      secret: getConfigValue(fileConfig, ['webhooks', 'secret'], process.env.WEBHOOK_SECRET),
     },
   };
 

--- a/packages/core/src/services/webhook-queue.ts
+++ b/packages/core/src/services/webhook-queue.ts
@@ -1,0 +1,197 @@
+import { eq, and, lte } from 'drizzle-orm';
+import { db, schema } from '../db';
+import { createLogger } from './logger';
+
+const logger = createLogger('core');
+
+/**
+ * Webhook queue service for managing document IDs received from Paperless-ngx webhooks.
+ * Follows the same patterns as RetryQueue for consistency.
+ */
+export class WebhookQueueService {
+  /**
+   * Insert a new webhook delivery into the queue.
+   * Idempotent: if documentId is already pending, skip (deduplication).
+   */
+  async enqueue(documentId: number, payload?: string): Promise<void> {
+    // Check for existing pending entry with same documentId
+    const existing = await db
+      .select()
+      .from(schema.webhookQueue)
+      .where(
+        and(
+          eq(schema.webhookQueue.documentId, documentId),
+          eq(schema.webhookQueue.status, 'pending')
+        )
+      )
+      .get();
+
+    if (existing) {
+      logger.debug(`Document ${documentId} already in webhook queue (pending), skipping duplicate`);
+      return;
+    }
+
+    await db
+      .insert(schema.webhookQueue)
+      .values({
+        documentId,
+        payload: payload ?? null,
+        status: 'pending',
+        receivedAt: new Date().toISOString(),
+      })
+      .run();
+
+    logger.info(`Document ${documentId} added to webhook queue`);
+  }
+
+  /**
+   * Get all pending document IDs and mark them as 'processing'.
+   * Atomically reads and updates status to prevent double-processing.
+   */
+  async consumePending(): Promise<number[]> {
+    const pending = await db
+      .select()
+      .from(schema.webhookQueue)
+      .where(eq(schema.webhookQueue.status, 'pending'))
+      .all();
+
+    if (pending.length === 0) {
+      return [];
+    }
+
+    // Mark all as processing
+    for (const item of pending) {
+      await db
+        .update(schema.webhookQueue)
+        .set({ status: 'processing' })
+        .where(eq(schema.webhookQueue.id, item.id))
+        .run();
+    }
+
+    const ids = pending.map(item => item.documentId);
+    logger.info(`Consumed ${ids.length} document(s) from webhook queue: [${ids.join(', ')}]`);
+    return ids;
+  }
+
+  /**
+   * Mark a document as completed.
+   */
+  async markCompleted(documentId: number): Promise<void> {
+    await db
+      .update(schema.webhookQueue)
+      .set({
+        status: 'completed',
+        processedAt: new Date().toISOString(),
+      })
+      .where(
+        and(
+          eq(schema.webhookQueue.documentId, documentId),
+          eq(schema.webhookQueue.status, 'processing')
+        )
+      )
+      .run();
+  }
+
+  /**
+   * Mark a document as failed.
+   */
+  async markFailed(documentId: number): Promise<void> {
+    await db
+      .update(schema.webhookQueue)
+      .set({
+        status: 'failed',
+        processedAt: new Date().toISOString(),
+      })
+      .where(
+        and(
+          eq(schema.webhookQueue.documentId, documentId),
+          eq(schema.webhookQueue.status, 'processing')
+        )
+      )
+      .run();
+  }
+
+  /**
+   * Check if there are any pending items.
+   */
+  async hasPending(): Promise<boolean> {
+    const item = await db
+      .select()
+      .from(schema.webhookQueue)
+      .where(eq(schema.webhookQueue.status, 'pending'))
+      .get();
+
+    return !!item;
+  }
+
+  /**
+   * Get queue statistics for the status endpoint.
+   */
+  async getStats(): Promise<{
+    pending: number;
+    processing: number;
+    completed: number;
+    failed: number;
+    total: number;
+  }> {
+    const all = await db
+      .select()
+      .from(schema.webhookQueue)
+      .all();
+
+    const stats = { pending: 0, processing: 0, completed: 0, failed: 0, total: all.length };
+    for (const item of all) {
+      if (item.status === 'pending') stats.pending++;
+      else if (item.status === 'processing') stats.processing++;
+      else if (item.status === 'completed') stats.completed++;
+      else if (item.status === 'failed') stats.failed++;
+    }
+    return stats;
+  }
+
+  /**
+   * Get recent webhook deliveries for the history endpoint.
+   */
+  async getRecent(limit: number = 50): Promise<schema.WebhookQueueEntry[]> {
+    return await db
+      .select()
+      .from(schema.webhookQueue)
+      .orderBy(schema.webhookQueue.id)
+      .limit(limit)
+      .all();
+  }
+
+  /**
+   * Clean up old completed entries (older than N days).
+   * Returns the number of entries removed.
+   */
+  async cleanup(olderThanDays: number = 7): Promise<number> {
+    const cutoff = new Date(Date.now() - olderThanDays * 24 * 60 * 60 * 1000).toISOString();
+
+    const old = await db
+      .select()
+      .from(schema.webhookQueue)
+      .where(
+        and(
+          eq(schema.webhookQueue.status, 'completed'),
+          lte(schema.webhookQueue.processedAt, cutoff)
+        )
+      )
+      .all();
+
+    if (old.length === 0) return 0;
+
+    for (const item of old) {
+      await db
+        .delete(schema.webhookQueue)
+        .where(eq(schema.webhookQueue.id, item.id))
+        .run();
+    }
+
+    logger.info(`Cleaned up ${old.length} completed webhook entries older than ${olderThanDays} days`);
+    return old.length;
+  }
+}
+
+// Singleton instance
+export const webhookQueueService = new WebhookQueueService();

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -50,6 +50,10 @@ export const ConfigSchema = z.object({
     heliconeEnabled: z.boolean().default(false),
     heliconeApiKey: z.string().optional(),
   }).optional().default({ heliconeEnabled: false }),
+  webhooks: z.object({
+    enabled: z.boolean().default(false),
+    secret: z.string().optional(), // Bearer token for validating Paperless-ngx webhook requests
+  }).optional().default({ enabled: false }),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;
@@ -93,6 +97,10 @@ export const PartialConfigSchema = z.object({
   observability: z.object({
     heliconeEnabled: z.boolean().optional(),
     heliconeApiKey: z.string().optional(),
+  }).optional(),
+  webhooks: z.object({
+    enabled: z.boolean().optional(),
+    secret: z.string().optional(),
   }).optional(),
 });
 


### PR DESCRIPTION
## Summary

Implements hybrid webhook + polling architecture for Paperless-ngx integration, enabling near-instant receipt processing when documents are added.

Closes #5

## Changes

### Backend
- **Config Schema**: Added `webhooks` section (`enabled`, `secret`) to `ConfigSchema` and `PartialConfigSchema`
- **Database**: Added `webhook_queue` table via Drizzle migration for tracking webhook deliveries
- **Core Service**: `WebhookQueueService` with idempotent enqueue, atomic consume, status tracking, and periodic cleanup
- **Bridge**: Added `processDocumentsByIds()` for targeted document processing (skips discovery phase)
- **API Routes**: 
  - `POST /api/webhooks/paperless` — Receives Paperless-ngx workflow webhooks with Bearer token auth
  - `GET /api/webhooks/status` — Returns webhook config state and queue stats
  - `GET /api/webhooks/history` — Recent webhook deliveries

### Worker
- Modified worker loop to check webhook queue **before** scheduled/manual scans (priority processing)
- Webhook-queued documents are processed immediately with proper lock acquisition
- Periodic cleanup of completed webhook entries (hourly)

### Frontend
- Added Webhooks card to Settings page with:
  - Enable/disable toggle
  - Read-only webhook URL with copy button
  - Secret token input with random generation
  - Live queue status display (pending/processing/completed/failed)
  - Step-by-step Paperless-ngx workflow setup instructions

## Architecture

```
Paperless-ngx → POST /api/webhooks/paperless → webhook_queue → Worker → processDocumentsByIds()
                                                    ↑
                                        Worker polls every 5s
```

- Webhooks enqueue document IDs and trigger an immediate worker scan
- Worker checks webhook queue first (priority), then falls back to scheduled scanning
- Paperless has a 5s timeout with 3 retries — endpoint responds immediately after enqueueing
- No HMAC support in Paperless; uses Bearer token in custom header for auth

## Testing

- All TypeScript packages pass typecheck (`pnpm turbo typecheck`)
- LSP diagnostics clean on all modified files