### PR TITLE
fix: docker startup and webapp host configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,5 +69,9 @@ RUN cd apps/webapp && pnpm run build
 # Expose webapp port only - API (3001) and Worker are internal
 EXPOSE 3000
 
-# Default command - start production server via turborepo
-CMD ["pnpm", "run", "start"]
+# Install NodeJS for the next command
+RUN apt-get update && apt-get install -y nodejs npm && rm -rf /var/lib/apt/lists/*
+
+# 1. Setup database (creates SQLite file and runs migrations)
+# 2. Start worker, API, and webapp concurrently
+CMD ["sh","-lc","cd /app && pnpm --filter @sm-rn/core run db:setup && (cd apps/worker && pnpm run start) & (cd apps/api && pnpm run start) & cd apps/webapp && pnpm run start"]

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite dev --port 3000 --host",
     "build": "vite build",
-    "start": "vite preview --port 3000 --host",
+    "start": "vite preview --port 3000 --host --strictPort",
     "preview": "vite preview",
     "test": "vitest run",
     "lint": "eslint",

--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -6,7 +6,13 @@ import viteTsConfigPaths from 'vite-tsconfig-paths'
 import tailwindcss from '@tailwindcss/vite'
 import { nitro } from 'nitro/vite'
 
+const allowed = (process.env.ALLOWED_HOSTS || 'localhost')
+  .split(',')
+  .map((h) => h.trim())
+
 const config = defineConfig({
+  server: { host: true, allowedHosts: allowed },
+  preview: { host: true, allowedHosts: allowed },
   plugins: [
     devtools(),
     nitro(),


### PR DESCRIPTION
- Replace single pnpm start with multi-process CMD that runs db:setup, worker, API, and webapp concurrently
- Install nodejs/npm in Docker image for db:setup script
- Add --strictPort to webapp preview to fail on port conflicts
- Configure Vite allowedHosts via ALLOWED_HOSTS env var for container access

NOTE: The changes in this PR resolve the following issue in the source repository:
https://github.com/smashah/receipthero-ng/issues/18
